### PR TITLE
use the find library method from ctypes.util to find the shared library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 __pycache__/
+build/
+dist/
 *.pyc
 *.swp
 *.swo

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ ngspice](http://ngspice.sourceforge.net/download.html) and compile it like this:
     make
     sudo make install
 
+On OSX, libngspice can be installed with brew. Note that the ngspice package does not supply the required shared libraries. 
+
 On Windows, it currently assumes that `ngspice.dll` is installed in
 `C:\Spice\bin_dll` (32-bit Python) or `C:\Spice64\bin_dll` (64-bit Python).
 Go to [Ngspice Download](http://ngspice.sourceforge.net/download.html) and

--- a/ngspyce/ngspyce.py
+++ b/ngspyce/ngspyce.py
@@ -17,6 +17,7 @@ __all__ = [
     'vector',
     'try_float',
     'model_parameters',
+    'device_state',
     'alter_model',
     'ac',
     'dc',
@@ -488,6 +489,17 @@ def model_parameters(device=None, model=None):
             lines = cmd('showmod ' + device.lower())
         else:
             raise ValueError('Only specify one of device, model')
+    ret = dict(description=lines.pop(0))
+    ret.update({parts[0]: try_float(parts[1])
+                for parts in map(str.split, lines)})
+    return ret
+
+def device_state(device):
+    """
+    Return dict with device state
+    """
+    lines = cmd('show ' + device.lower())
+
     ret = dict(description=lines.pop(0))
     ret.update({parts[0]: try_float(parts[1])
                 for parts in map(str.split, lines)})

--- a/ngspyce/ngspyce.py
+++ b/ngspyce/ngspyce.py
@@ -1,6 +1,8 @@
 from ctypes import (CDLL, CFUNCTYPE, Structure, c_int, c_char_p, c_void_p,
                     c_bool, c_double, POINTER, pointer, cast, c_short,
                     py_object)
+
+from ctypes.util import find_library
 import numpy as np
 import logging
 import os
@@ -60,7 +62,7 @@ if os.name == 'nt':  # Windows
     spice = CDLL('ngspice')
     os.chdir(curr_dir_before)
 else:  # Linux, etc.
-    spice = CDLL('libngspice.so')
+    spice = CDLL(find_library('libngspice'))
 
 captured_output = []
 


### PR DESCRIPTION
CDLL("libngspice.so") fails on my mac because the libraries are really at "/usr/local/lib/libngspice.dylib", using find_library seems to fix the issue though I don't know if this is the best method.